### PR TITLE
fix the problem of importing packages in "run_mapper.py"

### DIFF
--- a/examples/run_mapper.py
+++ b/examples/run_mapper.py
@@ -12,8 +12,8 @@ import argparse
 
 from torch.utils.data.dataloader import DataLoader
 
-import examples.demo_utils as demo_utils
-from examples.timer import Timer
+import demo_utils as demo_utils
+from timer import Timer
 from nvblox_torch.datasets.rtmv_dataset import RtmvDataset
 from nvblox_torch.datasets.sun3d_dataset import Sun3dDataset
 from nvblox_torch.mapper import (


### PR DESCRIPTION
Hi! The current examples that need to run `python examples/run_mapper.py` have problems when importing packages. 

```
Traceback (most recent call last):
  File "/pkgs/nvblox_torch/examples/run_mapper.py", line 15, in <module>
    import examples.demo_utils as demo_utils
ModuleNotFoundError: No module named 'examples.demo_utils'
```

It will be better to change the path of `run_mapper.py` or fix the bugs.